### PR TITLE
Add information for existing support pages

### DIFF
--- a/data/015/2004/en_US.json
+++ b/data/015/2004/en_US.json
@@ -1,0 +1,13 @@
+{
+	"015": {
+		"2004": {
+			"name": "Unknown",
+			"message": "Unable to connect to the server.\nPlease try again later.\n\nFor help, visit support.nintendo.com",
+			"short_description": "Console failed to connect to the server",
+			"long_description": "This error indicates a connection problem with the server.",
+			"short_solution": "Check server status and try again later",
+			"long_solution": "- **Check our network status information**\n> Check our [Network Status page](https://stats.uptimerobot.com/R7E4wiGjJq) and ensure that there are no ongoing service outages.\n\n- **Ensure your console can connect to the internet and try again**\n> Try performing a connection test in system settings. If the connection test fails, there is likely another issues on your network",
+			"support_link": ""
+		}
+	}
+}

--- a/data/015/5001/en_US.json
+++ b/data/015/5001/en_US.json
@@ -1,11 +1,11 @@
 {
 	"015": {
-		"5004": {
+		"5001": {
 			"name": "Unknown",
-			"message": "The Miiverse service has ended. Miiverse and any software features that make use of Miiverse will no longer be available. Thank you for your Interest.",
-			"short_description": "Juxtaposition is shut down",
-			"long_description": "Juxtaposition has stop operation. This error should not occur under normal conditions when connected to Pretendo Network.",
-			"short_solution": "Self host, use another Juxtaposition instance, or use https://github.com/rverseTeam",
+			"message": "A system update is required. Go to System Settings to perform a system update.",
+			"short_description": "A system update must be installed before launch",
+			"long_description": "The title will not launch until a system update is performed. This error should not occur under normal conditions when connected to Pretendo Network.",
+			"short_solution": "Boot the Miiverse applet from the home screen and complete setup",
 			"long_solution": "- **Check that you are patched**\n\n1. Open System Settings on the 3DS HOME Menu.\n2. Click on `Nintendo Network ID Settings`.\n3. Navigate to the 3RD Page, and select `Other`.4. Click on `Network Services Agreement`.\n - If the top of the lower screen says `Pretendo Network Services Agreement`, then you are connected to Pretendo Network.\n - If the top of the lower screen says something else, then you are not connected to Pretendo Network. Follow [these](/docs/install/3ds) instructions to get started.",
 			"support_link": ""
 		}

--- a/data/015/5002/en_US.json
+++ b/data/015/5002/en_US.json
@@ -4,9 +4,9 @@
 			"name": "Unknown",
 			"message": "You must have started Miiverse\nat least once before you can\nuse this online service.\n\nPlease start Miiverse from\nthe HOME Menu and set up\nyour user information",
 			"short_description": "Juxtaposition account not initialized",
-			"long_description": "",
+			"long_description": "This error occurs when you have never opened the Miiverse app before attempting to use online features.",
 			"short_solution": "Boot the Miiverse applet from the home screen and complete setup",
-			"long_solution": "",
+			"long_solution": "Open the Miiverse app from the HOME Menu.",
 			"support_link": ""
 		}
 	}

--- a/data/015/5003/en_US.json
+++ b/data/015/5003/en_US.json
@@ -4,9 +4,9 @@
 			"name": "Unknown",
 			"message": "The server is currently undergoing\nmaintenance. We apologize for any\ninconvenience. Please try again later.\n\nTo learn more about maintenance,\nvisit support.nintendo.com",
 			"short_description": "Juxtaposition is under maintenance",
-			"long_description": "",
+			"long_description": "Juxtaposition is currently undergoing maintenance.",
 			"short_solution": "Try again later",
-			"long_solution": "",
+			"long_solution": "Check our [Network Status page](https://stats.uptimerobot.com/R7E4wiGjJq) or join our [Discord server](https://invite.gg/pretendo) for updates.",
 			"support_link": ""
 		}
 	}

--- a/data/015/5005/en_US.json
+++ b/data/015/5005/en_US.json
@@ -1,12 +1,12 @@
 {
-	"115": {
+	"015": {
 		"5005": {
 			"name": "Unknown",
 			"message": "You cannot use Miiverse because it has been restricted in Parental Controls.",
-			"short_description": "Parental Controls have blocked your ability to access Juxtaposition",
+			"short_description": "Access blocked by Parental Controls",
 			"long_description": "This error occurs when Miiverse has been disallowed by Parental Controls.",
-			"short_solution": "Review your Parental Controls settings",
-			"long_solution": "Disable Parental Controls.",
+			"short_solution": "Disable Parental Controls",
+			"long_solution": "Disable Parental Controls",
 			"support_link": ""
 		}
 	}

--- a/data/015/5006/en_US.json
+++ b/data/015/5006/en_US.json
@@ -1,0 +1,13 @@
+{
+	"015": {
+		"5006": {
+			"name": "Unknown",
+			"message": "You may not post to Miiverse due to a restriction in Parental Controls",
+			"short_description": "Posting blocked by Parental Controls",
+			"long_description": "This error occurs when posting to Miiverse has been disallowed by Parental Controls.",
+			"short_solution": "Disable Parental Controls",
+			"long_solution": "Disable Parental Controls",
+			"support_link": ""
+		}
+	}
+}

--- a/data/015/5007/en_US.json
+++ b/data/015/5007/en_US.json
@@ -4,9 +4,9 @@
 			"name": "Unknown",
 			"message": "Miiverse functions are unavailable\nto this Nintendo Network ID.\n\nFor details, please start Miiverse",
 			"short_description": "Your PNID has been banned from Juxtaposition",
-			"long_description": "",
-			"short_solution": "Don't do whatever you did to get banned",
-			"long_solution": "",
+			"long_description": "This typically occurs because you are attempting to connect to Juxtaposition with a **Nintendo Network ID** instead of a **Pretendo Network ID**.\n\nThis can also occur if your Pretendo Network ID has been banned from using Juxtaposition.",
+			"short_solution": "N/A",
+			"long_solution": "For more information, launch the Miiverse app, or request to speak to a moderator in the [Discord server](https://invite.gg/pretendo)",
 			"support_link": ""
 		}
 	}

--- a/data/015/5015/en_US.json
+++ b/data/015/5015/en_US.json
@@ -1,0 +1,13 @@
+{
+	"015": {
+		"5015": {
+			"name": "Unknown",
+			"message": "Unable to connect to the server. Please try again later. If the problem persists, please make a note of the error code and visit support.nintendo.com.",
+			"short_description": "Server error",
+			"long_description": "This error indicates a connection problem with the server.",
+			"short_solution": "Check server status and try again later",
+			"long_solution": "- **Check our network status information**\n> Check our [Network Status page](https://stats.uptimerobot.com/R7E4wiGjJq) and ensure that there are no ongoing service outages.\n\n- **Ensure your 3DS can connect to the internet and try again**\n> Try performing a connection test in system settings. If the connection test fails, there is likely another issues on your network",
+			"support_link": ""
+		}
+	}
+}

--- a/data/102/2482/en_US.json
+++ b/data/102/2482/en_US.json
@@ -2,11 +2,11 @@
 	"102": {
 		"2482": {
 			"name": "INVALID_GAME_SERVER_ID",
-			"message": "",
+			"message": "Unable to connect to the server. Please try again later. If the problem persists, please make a note of the error code and visit support.nintendo.com.",
 			"short_description": "The game server requested could not be found. Either the game is not supported or is tester-only",
-			"long_description": "",
+			"long_description": "This error indicates one of the following:\n\n1. The server you're connecting to is offline for maintenance.\n\n2. Pretendo does not yet support the game or application in question.\n3. The game or application's server is not available for your accounts environment. This typically means the server is in beta testing and is not available to the public. Beta servers are generally only available to [supporters](https://pretendo.network/account/upgrade).",
 			"short_solution": "Check to see if your game is supported at https://pretendo.network/progress. If you're a tester, check your account is set to Beta at https://pretendo.network/account",
-			"long_solution": "",
+			"long_solution": "- **Check our network status information**\n> Check our [Network Status page](https://stats.uptimerobot.com/R7E4wiGjJq) and ensure that there are no ongoing service outages.\n\n- **Check Pretendo has a server for your game**\n> Check our [Progress page](https://pretendo.network/progress) to see if a server exists and is in development. We don't support everything yet!\n\n- **Upgrade your account**\n> Certain beta and development servers are available to supporters for beta-testing. If you'd like to help test these ahead of a public release, [consider supporting Pretendo](https://pretendo.network/account/upgrade).",
 			"support_link": ""
 		}
 	}

--- a/data/115/2004/en_US.json
+++ b/data/115/2004/en_US.json
@@ -1,0 +1,13 @@
+{
+	"115": {
+		"2004": {
+			"name": "Unknown",
+			"message": "Unable to connect to the server. Please try again later. If the problem persists, please make a note of the error code and visit support.nintendo.com.",
+			"short_description": "Server error",
+			"long_description": "This error indicates a connection problem with the server.",
+			"short_solution": "Check server status and try again later",
+			"long_solution": "- **Check our network status information**\n> Check our [Network Status page](https://stats.uptimerobot.com/R7E4wiGjJq) and ensure that there are no ongoing service outages.\n\n- **Ensure your 3DS can connect to the internet and try again**\n> Try performing a connection test in system settings. If the connection test fails, there is likely another issues on your network",
+			"support_link": ""
+		}
+	}
+}

--- a/data/115/5001/en_US.json
+++ b/data/115/5001/en_US.json
@@ -4,9 +4,9 @@
 			"name": "Unknown",
 			"message": "A System update is required. Go to System Settings to perform a system update.",
 			"short_description": "Your console is not up to date",
-			"long_description": "",
+			"long_description": "This error should not occur under normal conditions when connected to Pretendo Network.",
 			"short_solution": "Update your console",
-			"long_solution": "",
+			"long_solution": "- **Check that you are patched**\n\n1. On the Wii U System Menu, click on your Mii in the top left corner.\n2. Scroll down and select `View Network Services Agreement` button.\n3. Select the language of your choice.\n - If the top of the screen says `Pretendo Network Services Agreement`, then you are connected to Pretendo Network.\n - If the top of the screen says something else, then you are not connected to Pretendo Network. Follow [these](/docs/install/wiiu) instructions to get started.\n\n- **Update your console**\n - As of now, version 5.5.6 is safe to update for homebrew.\n - By default, modern homebrew environments block updates to ensure patches are not broken. You can follow [this](https://wiiu.hacks.guide/#/unblock-updates) guide to unblock updates.",
 			"support_link": ""
 		}
 	}

--- a/data/115/5002/en_US.json
+++ b/data/115/5002/en_US.json
@@ -4,9 +4,9 @@
 			"name": "Unknown",
 			"message": "You must have started Miiverse\nat least once before you can\nuse this online service.\n\nPlease start Miiverse from\nthe HOME Menu and set up\nyour user information.",
 			"short_description": "Juxtaposition account not initialized",
-			"long_description": "",
+			"long_description": "This error occurs when you have never opened the Miiverse app before attempting to use online features.",
 			"short_solution": "Boot the Miiverse applet from the home screen and complete setup",
-			"long_solution": "",
+			"long_solution": "Open the Miiverse app from the HOME Menu.",
 			"support_link": ""
 		}
 	}

--- a/data/115/5003/en_US.json
+++ b/data/115/5003/en_US.json
@@ -4,9 +4,9 @@
 			"name": "Unknown",
 			"message": "The server is currently undergoing\nmaintenance.\n\nPlease try again later.",
 			"short_description": "Juxtaposition is under maintenance",
-			"long_description": "",
+			"long_description": "Juxtaposition is currently undergoing maintenance.",
 			"short_solution": "Try again later",
-			"long_solution": "",
+			"long_solution": "Check our [Network Status page](https://stats.uptimerobot.com/R7E4wiGjJq) or join our [Discord server](https://invite.gg/pretendo) for updates.",
 			"support_link": ""
 		}
 	}

--- a/data/115/5004/en_US.json
+++ b/data/115/5004/en_US.json
@@ -4,9 +4,9 @@
 			"name": "Unknown",
 			"message": "The Miiverse service has ended.\nMiiverse and any software features\nthat make use of Miiverse will no\nlonger be available.\n\nThank you for your interest.",
 			"short_description": "Juxtaposition is shut down",
-			"long_description": "",
+			"long_description": "This error should not occur under normal conditions when connected to Pretendo Network.",
 			"short_solution": "Self host, use another Juxtaposition instance, or use https://github.com/rverseTeam",
-			"long_solution": "",
+			"long_solution": "- **Check that you are patched**\n\n1. On the Wii U System Menu, click on your Mii in the top left corner.\n2. Scroll down and select `View Network Services Agreement` button.\n3. Select the language of your choice.\n - If the top of the screen says `Pretendo Network Services Agreement`, then you are connected to Pretendo Network.\n - If the top of the screen says something else, then you are not connected to Pretendo Network. Follow [these](/docs/install/wiiu) instructions to get started.",
 			"support_link": ""
 		}
 	}

--- a/data/115/5006/en_US.json
+++ b/data/115/5006/en_US.json
@@ -4,9 +4,9 @@
 			"name": "Unknown",
 			"message": "You may not post to Miiverse due to a restriction in Parental Controls.",
 			"short_description": "Parental Controls have blocked your ability to post on Juxtaposition",
-			"long_description": "",
+			"long_description": "This error occurs when posting to Miiverse has been disallowed by Parental Controls.",
 			"short_solution": "Review your Parental Controls settings",
-			"long_solution": "",
+			"long_solution": "Disable Parental Controls.",
 			"support_link": ""
 		}
 	}

--- a/data/115/5007/en_US.json
+++ b/data/115/5007/en_US.json
@@ -4,9 +4,9 @@
 			"name": "Unknown",
 			"message": "Miiverse functions are unavailable\nto this Nintendo Network ID.\n\nFor details, please start Miiverse.",
 			"short_description": "Your PNID has been banned from Juxtaposition",
-			"long_description": "",
-			"short_solution": "Don't do whatever you did to get banned",
-			"long_solution": "",
+			"long_description": "This typically occurs because you are attempting to connect to Juxtaposition with a **Nintendo Network ID** instead of a **Pretendo Network ID**.\n\nThis can also occur if your Pretendo Network ID has been banned from using Juxtaposition.",
+			"short_solution": "N/A",
+			"long_solution": "For more information, launch the Miiverse app, or request to speak to a moderator in the [Discord server](https://invite.gg/pretendo).",
 			"support_link": ""
 		}
 	}

--- a/data/115/5015/en_US.json
+++ b/data/115/5015/en_US.json
@@ -1,0 +1,13 @@
+{
+	"115": {
+		"5015": {
+			"name": "Unknown",
+			"message": "Unable to connect to the server. Please try again later. If the problem persists, please make a note of the error code and visit support.nintendo.com.",
+			"short_description": "Server error",
+			"long_description": "This error indicates a connection problem with the server.",
+			"short_solution": "Check server status and try again later",
+			"long_solution": "- **Check our network status information**\n - Check our [Network Status page](https://stats.uptimerobot.com/R7E4wiGjJq) and ensure that there are no ongoing service outages.\n\n- **Ensure your Wii U can connect to the internet and try again**\n - Try performing a connection test in system settings. If the connection test fails, there is likely another issues on your network",
+			"support_link": ""
+		}
+	}
+}

--- a/data/598/0009/en_US.json
+++ b/data/598/0009/en_US.json
@@ -4,9 +4,9 @@
 			"name": "598-0009",
 			"message": "",
 			"short_description": "User limited from posting",
-			"long_description": "",
+			"long_description": "Your Pretendo Network ID has been limited from posting on Juxtaposition.\n\nThis typically occurs because of a violation of the Code of Conduct, or other offense on the Network or the Discord server.",
 			"short_solution": "Contact a moderator to appeal",
-			"long_solution": "",
+			"long_solution": "For more information, launch the Miiverse app, or request to speak to a moderator in the [Discord server](https://invite.gg/pretendo).",
 			"support_link": ""
 		}
 	}

--- a/data/598/0010/en_US.json
+++ b/data/598/0010/en_US.json
@@ -4,9 +4,9 @@
 			"name": "598-0010",
 			"message": "",
 			"short_description": "User temporary banned",
-			"long_description": "",
+			"long_description": "Your Pretendo Network ID has been temporarily banned from Juxtaposition.\n\nThis typically occurs because of a violation of the Code of Conduct, or other offense on the Network or the Discord server.",
 			"short_solution": "Contact a moderator to appeal",
-			"long_solution": "",
+			"long_solution": "For more information, launch the Miiverse app, or request to speak to a moderator in the [Discord server](https://invite.gg/pretendo).",
 			"support_link": ""
 		}
 	}

--- a/data/598/0011/en_US.json
+++ b/data/598/0011/en_US.json
@@ -4,9 +4,9 @@
 			"name": "598-0011",
 			"message": "",
 			"short_description": "User permanently banned",
-			"long_description": "",
+			"long_description": "Your Pretendo Network ID has been permanently banned from Juxtaposition.\n\nThis typically occurs because of a violation of the Code of Conduct, or other offense on the Network or the Discord server.",
 			"short_solution": "Contact a moderator to appeal",
-			"long_solution": "",
+			"long_solution": "For more information, launch the Miiverse app, or request to speak to a moderator in the [Discord server](https://invite.gg/pretendo).",
 			"support_link": ""
 		}
 	}

--- a/data/598/0020/en_US.json
+++ b/data/598/0020/en_US.json
@@ -2,11 +2,11 @@
 	"598": {
 		"0020": {
 			"name": "598-0020",
-			"message": "",
+			"message": "Unable to parse service Token. Are you using a Nintendo Network ID?",
 			"short_description": "Service token present, unable to parsed (likely a Nintendo Network Account)",
-			"long_description": "",
+			"long_description": "The server could not correctly parse the service token. This typically occurs because you are attempting to connect to Juxtaposition with a **Nintendo Network ID** instead of a **Pretendo Network ID**.",
 			"short_solution": "Check if you are logging into a PNID and ran the patcher",
-			"long_solution": "",
+			"long_solution": "Ensure that the account you are using is a Pretendo Network ID, and that you have followed the setup guide for your console.",
 			"support_link": ""
 		}
 	}

--- a/data/598/0069/en_US.json
+++ b/data/598/0069/en_US.json
@@ -1,0 +1,13 @@
+{
+	"598": {
+		"0069": {
+			"name": "598-0069",
+			"message": "",
+			"short_description": "Miiverse app is patched with Martini",
+			"long_description": "You have the legacy Martini patches installed into your Miiverse applet. The current version of the Pretendo patchers have a safer version of these patches, so the older ones must be uninstalled.",
+			"short_solution": "Uninstall the Martini patches",
+			"long_solution": "Navigate to the [releases](https://github.com/PretendoNetwork/Martini/releases) page on the Martini GitHub repository.\n\nDownload the latest release and download `martini-juxt-patcher.rpx`.\n\nCopy `martini-juxt-patcher.rpx` and place it on your SD card at `sd:/wiiu/apps/`.\n\nPlace your SD card back into your console and boot like normal. Open the Homebrew Launcher and launch `martini-juxt-patcher.rpx` or select it from the Wii U Menu (Aroma).\n\nAfter confirming the state of the Miiverse applet, press X to remove the patches.\n\nIf you encountered any errors, try [searching](/docs/errors) for the error code. If that doesn't work, get in touch with a developer in our [Discord](https://invite.gg/pretendo).",
+			"support_link": ""
+		}
+	}
+}

--- a/data/598/en_US.json
+++ b/data/598/en_US.json
@@ -2,6 +2,6 @@
 	"598": {
 		"name": "Juxtaposition",
 		"description": "Pretendo Miiverse replacement",
-		"system": "Wii U"
+		"system": "Wii U / 3DS Family"
 	}
 }

--- a/data/678/1000/en_US.json
+++ b/data/678/1000/en_US.json
@@ -4,9 +4,9 @@
 			"name": "678-1000",
 			"message": "",
 			"short_description": "Juxtapostion has been installed successfully",
-			"long_description": "",
-			"short_solution": "",
-			"long_solution": "",
+			"long_description": "***Note:*** This error relates to the Martini patches, which are now deprecated.\n\nJuxtapostion has been installed successfully.",
+			"short_solution": "N/A",
+			"long_solution": "Not applicable",
 			"support_link": ""
 		}
 	}

--- a/data/678/1001/en_US.json
+++ b/data/678/1001/en_US.json
@@ -4,9 +4,9 @@
 			"name": "678-1001",
 			"message": "",
 			"short_description": "MCP failure, may be caused by HaxchiFW",
-			"long_description": "",
+			"long_description": "***Note:*** This error relates to the Martini patches, which are now deprecated.\n\nThe console's CFW is not compatible with Pretendo's patcher.",
 			"short_solution": "Restart your console",
-			"long_solution": "",
+			"long_solution": "If you are using Haxchi, Coldboot Haxchi, Indexiine, Browserhax or similar, please [upgrade to Tiramisu or Aroma](https://wiiu.hacks.guide) and try again.\n\nIf you're sure you're using Tiramisu or Aroma, reboot the console and try again. If the same error occurs, get in touch with a developer in our [Discord](https://invite.gg/pretendo).",
 			"support_link": ""
 		}
 	}

--- a/data/678/1002/en_US.json
+++ b/data/678/1002/en_US.json
@@ -4,9 +4,9 @@
 			"name": "678-1002",
 			"message": "",
 			"short_description": "Could not find Miiverse on your console",
-			"long_description": "",
-			"short_solution": "",
-			"long_solution": "",
+			"long_description": "***Note:*** This error relates to the Martini patches, which are now deprecated.\n\nThe patcher could not find a Miiverse applet installed on your console, or you have several Miiverses installed.",
+			"short_solution": "Restore Miiverse",
+			"long_solution": "If missing Miiverse and are on a retail unit, reinstall Miiverse (NAND backup). If you have multiple Miiverse titles installed, or are missing Miiverse on non-retail hardware, get in touch with a developer in our [Discord](https://invite.gg/pretendo) - we'd love to know what kind of devkit you have!",
 			"support_link": ""
 		}
 	}

--- a/data/678/1003/en_US.json
+++ b/data/678/1003/en_US.json
@@ -4,9 +4,9 @@
 			"name": "678-1003",
 			"message": "",
 			"short_description": "No compatable CFW found",
-			"long_description": "",
+			"long_description": "***Note:*** This error relates to the Martini patches, which are now deprecated.\n\nThe console's CFW is not compatible with Pretendo's patcher.",
 			"short_solution": "Please have Mocha running before opening Martini",
-			"long_solution": "",
+			"long_solution": "If you are using Haxchi, Coldboot Haxchi, Indexiine, Browserhax or similar, please [upgrade to Tiramisu or Aroma](https://wiiu.hacks.guide) and try again.\n\nIf you're sure you're using Tiramisu or Aroma, reboot the console and try again. If the same error occurs, get in touch with a developer in our [Discord](https://invite.gg/pretendo).",
 			"support_link": ""
 		}
 	}

--- a/data/678/1004/en_US.json
+++ b/data/678/1004/en_US.json
@@ -4,9 +4,9 @@
 			"name": "678-1004",
 			"message": "",
 			"short_description": "Failed to mount IOSU",
-			"long_description": "",
+			"long_description": "***Note:*** This error relates to the Martini patches, which are now deprecated.\n\nThe console's CFW is not compatible with Pretendo's patcher.",
 			"short_solution": "Restart your console",
-			"long_solution": "",
+			"long_solution": "If you are using Haxchi, Coldboot Haxchi, Indexiine, Browserhax or similar, please [upgrade to Tiramisu or Aroma](https://wiiu.hacks.guide) and try again.\n\nIf you're sure you're using Tiramisu or Aroma, reboot the console and try again. If the same error occurs, get in touch with a developer in our [Discord](https://invite.gg/pretendo).",
 			"support_link": ""
 		}
 	}

--- a/data/678/1005/en_US.json
+++ b/data/678/1005/en_US.json
@@ -4,9 +4,9 @@
 			"name": "678-1005",
 			"message": "",
 			"short_description": "Could not find a clean version of Miiverse applet or recovery files",
-			"long_description": "",
-			"short_solution": "",
-			"long_solution": "",
+			"long_description": "***Note:*** This error relates to the Martini patches, which are now deprecated.\n\nThe patcher could not find an unmodified copy of the Miiverse applet. Either you have manually modified it, it has become corrupted, or you have a version too old or too new for the patcher to recognise.",
+			"short_solution": "See support page",
+			"long_solution": "- If you are on a system version older than 5.1.0, perform a system update, install [Tiramisu or Aroma](https://wiiu.hacks.guide), and try again.\n- Try disabling any content replacement plugins (SDCafiine etc.) that can change which files are read by the patcher.\n- If you have manually modified your Miiverse applet, reinstall a clean copy from a backup. Instructions for this cannot be provided by Pretendo.\n\nIf all of these failed, get in touch on our [Discord](https://invite.gg/pretendo).",
 			"support_link": ""
 		}
 	}

--- a/data/678/1006/en_US.json
+++ b/data/678/1006/en_US.json
@@ -4,9 +4,9 @@
 			"name": "678-1006",
 			"message": "",
 			"short_description": "Could not find a clean version of NSSL cert",
-			"long_description": "",
-			"short_solution": "",
-			"long_solution": "",
+			"long_description": "***Note:*** This error relates to the Martini patches, which are now deprecated.\n\nThe patcher could not find an unmodified copy of the Thwate Premium SSL certificate. Either you have manually replaced your SSL certificates, they have become corrupted, or your system version is too old or too new for the patcher to recognise.",
+			"short_solution": "See support page",
+			"long_solution": "- If you are on a system version older than 5.5.3, perform a system update, install [Tiramisu or Aroma](https://wiiu.hacks.guide), and try again.\n- Try disabling any content replacement plugins (SDCafiine etc.) that can change which files are read by the patcher.\n- If you have manually modified your SSL certificates - such as when using a proxy - reinstall a clean copy from a backup. Instructions for this cannot be provided by Pretendo.\n\nIf all of these failed, get in touch on our [Discord](https://invite.gg/pretendo).",
 			"support_link": ""
 		}
 	}

--- a/data/678/1007/en_US.json
+++ b/data/678/1007/en_US.json
@@ -4,9 +4,9 @@
 			"name": "678-1007",
 			"message": "",
 			"short_description": "Failed to create a backup",
-			"long_description": "",
+			"long_description": "***Note:*** This error relates to the Martini patches, which are now deprecated.\n\nThe patcher failed to write out a backup of your Miiverse applet to NAND. This can be caused by an incompatible CFW or corrupted NAND.",
 			"short_solution": "Try again?",
-			"long_solution": "",
+			"long_solution": "Try updating to the [latest Tiramisu](https://tiramisu.foryour.cafe) or [latest Aroma](https://aroma.foryour.cafe) build, as these often contain fixes to the CFW.\n\nIf the issue persists, get in touch in our [Discord](https://invite.gg/pretendo).",
 			"support_link": ""
 		}
 	}

--- a/data/678/1008/en_US.json
+++ b/data/678/1008/en_US.json
@@ -4,9 +4,9 @@
 			"name": "678-1008",
 			"message": "",
 			"short_description": "Failed to patch Miiverse\nYour system has not been modified",
-			"long_description": "",
+			"long_description": "***Note:*** This error relates to the Martini patches, which are now deprecated.\n\nThe patcher failed to create a patched version of a file. The original file has not been modified.",
 			"short_solution": "Try running Martini again.",
-			"long_solution": "",
+			"long_solution": "Reboot your console and try again. If the issue persists, this is most likely a bug in the Martini patcher - please get in touch with a developer on our [Discord](https://invite.gg/pretendo).",
 			"support_link": ""
 		}
 	}

--- a/data/678/1009/en_US.json
+++ b/data/678/1009/en_US.json
@@ -4,9 +4,9 @@
 			"name": "678-1009",
 			"message": "",
 			"short_description": "Patch Created a Corrupted File\nYour system has not been modified",
-			"long_description": "",
+			"long_description": "***Note:*** This error relates to the Martini patches, which are now deprecated.\n\nThe patcher failed to create a patched version of a file. The original file has not been modified.",
 			"short_solution": "Try running Martini again.",
-			"long_solution": "",
+			"long_solution": "Reboot your console and try again. If the issue persists, this is most likely a bug in the Martini patcher - please get in touch with a developer on our [Discord](https://invite.gg/pretendo).",
 			"support_link": ""
 		}
 	}

--- a/data/678/1010/en_US.json
+++ b/data/678/1010/en_US.json
@@ -4,9 +4,9 @@
 			"name": "678-1010",
 			"message": "",
 			"short_description": ":warning: Patch created a corrupted file\n**YOUR SYSTEM HAS BEEN MODIFIED AND MAY BE IN AN UNSTABLE STATE**",
-			"long_description": "",
+			"long_description": "***Note:*** This error relates to the Martini patches, which are now deprecated.\n\n",
 			"short_solution": "Contact a developer immediately.",
-			"long_solution": "",
+			"long_solution": "The patcher encountered an error when applying the patched files to your system. Files on your NAND have been modified and your system is in an unknown state, though there should be no risk of bricking.\n\n<div class=\"tip\">\n⚠️ <b>Do not reboot your console</b>, return to the Wii U Menu or open the Miiverse applet. If you're uncomfortable diagnosing the issue yourself, reach out on our <a href=\"https://invite.gg/pretendo\" target=\"_blank\">Discord</a>.\n</div>\n\nIf you know what `udplogserver` is, start it now and save the output. Press HOME to exit the Martini patcher, then immediately open it again. If you see an error code, view its [documentation page](/docs/search), but remember not to reboot your console until the system is in a known state again. If, instead, you progress to the confirmation page, and you have the option to uninstall patches by pressing X, you may do so. If you are not given the option to uninstall any patches, reach out on our [Discord](https://invite.gg/pretendo), and include a photo of the confirmation screen.",
 			"support_link": ""
 		}
 	}

--- a/data/678/1011/en_US.json
+++ b/data/678/1011/en_US.json
@@ -4,9 +4,9 @@
 			"name": "678-1011",
 			"message": "",
 			"short_description": ":warning: **PATCH HAS FAILED TO REPLACE CERT\nYOUR SYSTEM MAY HAVE BRICKED**",
-			"long_description": "",
+			"long_description": "***Note:*** This error relates to the Martini patches, which are now deprecated.\n\n<div class=\"tip\">\n⚠️ <b>Do not reboot your console or exit Martini!</b>\n</div>\n\nThe patcher encountered an error when applying the patched certificate to your system. Files essential to your Wii U's functionality have been modified and the system may be unbootable. **Immediate action is required to avoid a brick.**",
 			"short_solution": "Contact a developer immediately.",
-			"long_solution": "",
+			"long_solution": "Reach out on our [Discord](https://invite.gg/pretendo). State your error code and that you have a cert brick. Be loud and ping mods. Do not stop pinging until someone responds - this is the only time you're allowed ;)\n\n\nPrecise instructions are not provided here to ensure that you get helpers involved. For helpers and experienced users, however, your best bet from here is to use wupclient (Tiramisu/Aroma) or FTP (Aroma) to download whatever Thwate cert is on the console and inspect it, then upload a clean one. Users who have EnvironmentLoader in H&S can install Tiramisu and should be able to use the boot selector to get to HBL and FTPiiU Everywhere without triggering the brick. Users without a working coldboot setup are SOL if they reboot, though UDPIH might be able to save it.",
 			"support_link": ""
 		}
 	}

--- a/data/678/1012/en_US.json
+++ b/data/678/1012/en_US.json
@@ -4,9 +4,9 @@
 			"name": "678-1012",
 			"message": "",
 			"short_description": "Juxtapostion has been uninstalled successfully",
-			"long_description": "",
-			"short_solution": "",
-			"long_solution": "",
+			"long_description": "***Note:*** This error relates to the Martini patches, which are now deprecated.\n\nJuxtapostion has been uninstalled successfully.",
+			"short_solution": "N/A",
+			"long_solution": "Not applicable",
 			"support_link": ""
 		}
 	}

--- a/data/678/1013/en_US.json
+++ b/data/678/1013/en_US.json
@@ -4,9 +4,9 @@
 			"name": "678-1013",
 			"message": "",
 			"short_description": "Uninstalling failed",
-			"long_description": "",
+			"long_description": "***Note:*** This error relates to the Martini patches, which are now deprecated.\n\nThe patcher failed to restore a file from its backup. The patched file remains in place.",
 			"short_solution": "Try again?",
-			"long_solution": "",
+			"long_solution": "Reboot your console and try again. If the issue persists, this is most likely a bug in the Martini patcher - please get in touch with a developer on our [Discord](https://invite.gg/pretendo).",
 			"support_link": ""
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@pretendonetwork/error-codes",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Translated error code information for the Wii U and 3DS"
 }


### PR DESCRIPTION
Adds information for errors that have existing support pages on the website. This removes the need to keep them in the website repo.