### PR TITLE
Wii U Account Settings error codes

### DIFF
--- a/data/727/0001/en_US.json
+++ b/data/727/0001/en_US.json
@@ -1,0 +1,13 @@
+{
+	"727": {
+		"0001": {
+			"name": "727-0001",
+			"message": "",
+			"short_description": "Changing your PNID country may cause unexpected results.",
+			"long_description": "The Wii U and 3DS family of systems relies on this data to determine the correct region for your account.\n\nChanging this setting may cause unexpected results.",
+			"short_solution": "Re-linking your PNID by deleting and re-adding the account will prevent this issue from occurring.",
+			"long_solution": "### On the Wii U\n1. Navigate to the User Settings Menu on the Wii U Gamepad\n2. Scroll down to \"Delete This User\"\n3. Enter you PNID password\n4. Select \"Next\", and accept the warning prompt\n> Note: Save Data will be lost when removing this user account. Make sure to back up your data with a tool like SaveMii before deleting the account. Once deleted, save data cannot be recovered\n5. Select Next to proceed\n6. Select \"Delete\" on the prompt\n7. Create a new user account and log back into your PNID",
+			"support_link": "https://pretendo.network/docs/install/wiiu#pnid-setup"
+		}
+	}
+}

--- a/data/727/0002/en_US.json
+++ b/data/727/0002/en_US.json
@@ -1,0 +1,13 @@
+{
+	"727": {
+		"0002": {
+			"name": "727-0002",
+			"message": "",
+			"short_description": "Changing your PNID birthday may cause unexpected results.",
+			"long_description": "The Wii U and 3DS family of systems do not normally allow you to change your birthday.\n\nChanging this setting may cause unexpected results.",
+			"short_solution": "Re-linking your PNID by deleting and re-adding the account will prevent this issue from occurring.",
+			"long_solution": "### On the Wii U\n1. Navigate to the User Settings Menu on the Wii U Gamepad\n2. Scroll down to \"Delete This User\"\n3. Enter you PNID password\n4. Select \"Next\", and accept the warning prompt\n> Note: Save Data will be lost when removing this user account. Make sure to back up your data with a tool like SaveMii before deleting the account. Once deleted, save data cannot be recovered\n5. Select Next to proceed\n6. Select \"Delete\" on the prompt\n7. Create a new user account and log back into your PNID",
+			"support_link": "https://pretendo.network/docs/install/wiiu#pnid-setup"
+		}
+	}
+}

--- a/data/727/en_US.json
+++ b/data/727/en_US.json
@@ -1,0 +1,7 @@
+{
+	"727": {
+		"name": "PNID Account Settings",
+		"description": "Pretendo Network ID Account Settings",
+		"system": "Wii U / 3DS Family"
+	}
+}


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves: N/A

### Changes:

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

This adds the error codes introduced in the PNID settings app for the Wii U [here](https://github.com/PretendoNetwork/account/pull/91).

Because this pr supplements that, an issue was not opened beforehand. If that's a concern, I'll put one in. It warns the user about potential issue changing the birthday or country of a PNID. It also guides the user on how to delete the Wii U account and add it back. Since changing these values isn't supported on the 3DS, I omitted those instructions for now. I would argue those would be best suited with different error codes anyway.

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.