### PR TITLE
feat: Add AC error names for 3DS

### DIFF
--- a/data/003/0299/en_US.json
+++ b/data/003/0299/en_US.json
@@ -1,7 +1,7 @@
 {
 	"003": {
 		"0299": {
-			"name": "Unknown",
+			"name": "nn::ac::ResultWifiOff",
 			"message": "",
 			"short_description": "Unknown cause.",
 			"long_description": "Unknown cause.",

--- a/data/003/0399/en_US.json
+++ b/data/003/0399/en_US.json
@@ -1,7 +1,7 @@
 {
 	"003": {
 		"0399": {
-			"name": "Unknown",
+			"name": "nn::ac::ResultNotAgreeEula",
 			"message": "",
 			"short_description": "Unknown cause.",
 			"long_description": "Unknown cause.",

--- a/data/003/1200/en_US.json
+++ b/data/003/1200/en_US.json
@@ -1,7 +1,7 @@
 {
 	"003": {
 		"1200": {
-			"name": "Unknown",
+			"name": "nn::ac::ResultConflictIpAddress",
 			"message": "Another device is using the same\nIP address, so the connection was \nrefused.\n\nGo to System Settings ⇒ Internet \nSettings and change your IP address",
 			"short_description": "Unknown cause.",
 			"long_description": "Unknown cause.",

--- a/data/003/1300/en_US.json
+++ b/data/003/1300/en_US.json
@@ -1,7 +1,7 @@
 {
 	"003": {
 		"1300": {
-			"name": "Unknown",
+			"name": "nn::ac::ResultUnsupportAuthAlgorithm",
 			"message": "Could not connect to the \naccess point.\n\nYou need to change the security\nsettings for this access point.\nChange these settings in System\nSettings ⇒ Internet Settings.\n\nFor help, visit support.nintendo.com",
 			"short_description": "Unknown cause.",
 			"long_description": "Unknown cause.",

--- a/data/003/2000/en_US.json
+++ b/data/003/2000/en_US.json
@@ -1,7 +1,7 @@
 {
 	"003": {
 		"2000": {
-			"name": "Unknown",
+			"name": "nn::ac::ResultInvalidDns",
 			"message": "Could not connect to the Internet.\n\n■ The security key or DNS may \nhave been entered incorrectly. Check \nthe setting in System Settings ⇒ \nInternet Settings.\n\n■ There may be problems with the \nnetwork or the environment.\nTo ensure an optimal connection \nenvironment, move closer to the \naccess point and make sure that there\nare no obstructions between the\nsystem and the access point.\nIf this does not work, please try \nagain later.\n\n■ Check that your computer can\nconnect to the Internet using the same\nsettings. If not, refer to the instruction\nbooklet that came with the access\npoint",
 			"short_description": "Unknown cause.",
 			"long_description": "Unknown cause.",

--- a/data/003/2001/en_US.json
+++ b/data/003/2001/en_US.json
@@ -1,7 +1,7 @@
 {
 	"003": {
 		"2001": {
-			"name": "Unknown",
+			"name": "nn::ac::ResultInvalidDns",
 			"message": "",
 			"short_description": "Unknown cause.",
 			"long_description": "Unknown cause.",

--- a/data/003/2100/en_US.json
+++ b/data/003/2100/en_US.json
@@ -1,7 +1,7 @@
 {
 	"003": {
 		"2100": {
-			"name": "Unknown",
+			"name": "nn::ac::ResultFailedConnTest",
 			"message": "Could not connect to the Internet.\n\nThe network may be busy, or there\nmay be problems with the connection\nenvironment. To ensure an optimal\nconnection environment, move closer\nto the access point and make sure that\nthere are no obstructions between\nthe system and the access point.\nIf this does not work, please try\nagain later.\n\n■ Check that your computer can\nconnect to the Internet using the same\nsettings. If not, refer to the instruction\nbooklet that came with your\naccess point.\n\n■ The DNS setting may have been \nentered incorrectly. Check the setting \nin System Settings ⇒ Internet \nSettings.\n\n■ The proxy server may have been\nentered incorrectly. Check the setting\nin System Settings ⇒ Internet \nSettings",
 			"short_description": "Unknown cause.",
 			"long_description": "Unknown cause.",

--- a/data/003/2101/en_US.json
+++ b/data/003/2101/en_US.json
@@ -1,7 +1,7 @@
 {
 	"003": {
 		"2101": {
-			"name": "Unknown",
+			"name": "nn::ac::ResultFailedConnTest",
 			"message": "",
 			"short_description": "Unknown cause.",
 			"long_description": "Unknown cause.",

--- a/data/003/2103/en_US.json
+++ b/data/003/2103/en_US.json
@@ -1,7 +1,7 @@
 {
 	"003": {
 		"2103": {
-			"name": "Unknown",
+			"name": "nn::ac::ResultFailedConnTest",
 			"message": "",
 			"short_description": "Unknown cause.",
 			"long_description": "Unknown cause.",

--- a/data/003/2200/en_US.json
+++ b/data/003/2200/en_US.json
@@ -1,7 +1,7 @@
 {
 	"003": {
 		"2200": {
-			"name": "Unknown",
+			"name": "nn::ac::ResultInvalidProxy",
 			"message": "Could not connect to the proxy server.\n\n■ Check that your computer can\nconnect to the Internet using the same\nsettings. If not, consult the\nadministrator of the proxy server.\n\n■ The proxy server may have been \nentered incorrectly. Check the setting \nin System Settings ⇒ Internet \nSettings",
 			"short_description": "Unknown cause.",
 			"long_description": "Unknown cause.",

--- a/data/003/3000/en_US.json
+++ b/data/003/3000/en_US.json
@@ -1,7 +1,7 @@
 {
 	"003": {
 		"3000": {
-			"name": "Unknown",
+			"name": "nn::ac::ResultUnsupportHotspot",
 			"message": "Could not connect to the \naccess point.\n\n■ This may be due to authentication\nproblems. Open the Internet browser,\nconnect to the Internet, and enter the\nrequired information (user name, \npassword, acceptance of user \nagreement, etc.).\n\n■ There may be problems with the \nnetwork or the environment.\nTo ensure an optimal connection \nenvironment, move closer to the \naccess point and make sure that there\nare no obstructions between the\nsystem and the access point.\n\n■ The network may be experiencing\nhigh traffic volumes or the service \nmay be down. \nPlease try again later",
 			"short_description": "Unknown cause.",
 			"long_description": "Unknown cause.",

--- a/data/003/3100/en_US.json
+++ b/data/003/3100/en_US.json
@@ -1,13 +1,13 @@
 {
 	"003": {
-		"1099": {
-			"name": "nn::ac::ResultNotFoundAccessPoint",
+		"3100": {
+			"name": "nn::ac::ResultFailedHotspotAuthentication",
 			"message": "",
 			"short_description": "Unknown cause.",
 			"long_description": "Unknown cause.",
 			"short_solution": "Unknown solution.",
 			"long_solution": "Unknown solution.",
-			"support_link": "https://preten.do/003-1099"
+			"support_link": "https://preten.do/003-3100"
 		}
 	}
 }

--- a/data/003/3200/en_US.json
+++ b/data/003/3200/en_US.json
@@ -1,13 +1,13 @@
 {
 	"003": {
-		"1099": {
-			"name": "nn::ac::ResultNotFoundAccessPoint",
+		"3200": {
+			"name": "nn::ac::ResultFailedHotspotConntest",
 			"message": "",
 			"short_description": "Unknown cause.",
 			"long_description": "Unknown cause.",
 			"short_solution": "Unknown solution.",
 			"long_solution": "Unknown solution.",
-			"support_link": "https://preten.do/003-1099"
+			"support_link": "https://preten.do/003-3200"
 		}
 	}
 }

--- a/data/003/3300/en_US.json
+++ b/data/003/3300/en_US.json
@@ -1,13 +1,13 @@
 {
 	"003": {
-		"1099": {
-			"name": "nn::ac::ResultNotFoundAccessPoint",
+		"3300": {
+			"name": "nn::ac::ResultUnsupportPlace",
 			"message": "",
 			"short_description": "Unknown cause.",
 			"long_description": "Unknown cause.",
 			"short_solution": "Unknown solution.",
 			"long_solution": "Unknown solution.",
-			"support_link": "https://preten.do/003-1099"
+			"support_link": "https://preten.do/003-3300"
 		}
 	}
 }

--- a/data/003/3305/en_US.json
+++ b/data/003/3305/en_US.json
@@ -1,7 +1,7 @@
 {
 	"003": {
 		"3305": {
-			"name": "Unknown",
+			"name": "nn::ac::ResultUnsupportPlace",
 			"message": "This service is not available in your\nlocation. Please use another service",
 			"short_description": "Unknown cause.",
 			"long_description": "Unknown cause.",

--- a/data/003/4199/en_US.json
+++ b/data/003/4199/en_US.json
@@ -1,13 +1,13 @@
 {
 	"003": {
-		"1099": {
-			"name": "nn::ac::ResultNotFoundAccessPoint",
+		"4199": {
+			"name": "nn::ac::ResultFailedStartup",
 			"message": "",
 			"short_description": "Unknown cause.",
 			"long_description": "Unknown cause.",
 			"short_solution": "Unknown solution.",
 			"long_solution": "Unknown solution.",
-			"support_link": "https://preten.do/003-1099"
+			"support_link": "https://preten.do/003-4199"
 		}
 	}
 }


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves #XXX

### Changes:

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

These error names were found inside a game with a function for logging an error result. The results were then mapped to the matching error codes using the conversion inside the code of the sysmodule.

The error names may be repeated among errors starting with the same pattern. This is intended, since the last two numbers represent unknown additional error information complementing the result (except for value 99, which can be mapped to a different error name).

Some of the error codes had multiple result names mapped to them. In those cases, no changes were made for clarity and avoid misinformation.

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.