### PR TITLE
Fix typo in short_solution message

### DIFF
--- a/data/022/5432/en_US.json
+++ b/data/022/5432/en_US.json
@@ -5,7 +5,7 @@
 			"message": "An error has occured. Please try again later. If the problem persists, please make a note of the error code and visit support.nintendo.com.",
 			"short_description": "Unknown cause.",
 			"long_description": "Unknown cause.",
-			"short_solution": "Open Nimbus and switch to Nintendo servers, then open the Nintendo eShop. After it loads or returns and error code, come back to Pretendo servers and try again.",
+			"short_solution": "Open Nimbus and switch to Nintendo servers, then open the Nintendo eShop. After it loads or returns an error code, come back to Pretendo servers and try again.",
 			"long_solution": "Follow this fix:\n\n1. Open Nimbus;\n2. Switch to Nintendo servers by tapping on Nintendo;\n3. Open the Nintendo eShop or another application that uses the NNID (e.g. Pokémon Bank) and wait until it loads or returns an error code;\n4. Once it's done, exit the eShop or the application you used for this fix;\n5. Open Nimbus again;\n6. Switch to Pretendo servers by tapping on Pretendo;\n7. Should be fixed! Attempt again at making/linking your PNID or whatever you were attempting to perform on Pretendo servers.",
 			"support_link": "https://preten.do/022-5432"
 		}


### PR DESCRIPTION
Changed "and error code" to "an error code"
I'm sorry it's my first pull request
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves #XXX

### Changes:

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [ ] I have tested all of my changes.