### PR TITLE
Fix: Some support URLs are wrong for 165 prefixed wii u error codes

### DIFF
--- a/data/165/3000/en_US.json
+++ b/data/165/3000/en_US.json
@@ -7,7 +7,7 @@
 			"long_description": "Unknown cause.",
 			"short_solution": "Unknown solution.",
 			"long_solution": "Unknown solution.",
-			"support_link": "https://preten.do/160-3000"
+			"support_link": "https://preten.do/165-3000"
 		}
 	}
 }

--- a/data/165/3423/en_US.json
+++ b/data/165/3423/en_US.json
@@ -7,7 +7,7 @@
 			"long_description": "Unknown cause.",
 			"short_solution": "Unknown solution.",
 			"long_solution": "Unknown solution.",
-			"support_link": "https://preten.do/160-3423"
+			"support_link": "https://preten.do/165-3423"
 		}
 	}
 }

--- a/data/165/6596/en_US.json
+++ b/data/165/6596/en_US.json
@@ -7,7 +7,7 @@
 			"long_description": "Unknown cause.",
 			"short_solution": "Unknown solution.",
 			"long_solution": "Unknown solution.",
-			"support_link": "https://preten.do/160-6596"
+			"support_link": "https://preten.do/165-6596"
 		}
 	}
 }

--- a/data/165/7457/en_US.json
+++ b/data/165/7457/en_US.json
@@ -7,7 +7,7 @@
 			"long_description": "Unknown cause.",
 			"short_solution": "Unknown solution.",
 			"long_solution": "Unknown solution.",
-			"support_link": "https://preten.do/160-7457"
+			"support_link": "https://preten.do/165-7457"
 		}
 	}
 }

--- a/data/165/8426/en_US.json
+++ b/data/165/8426/en_US.json
@@ -7,7 +7,7 @@
 			"long_description": "Unknown cause.",
 			"short_solution": "Unknown solution.",
 			"long_solution": "Unknown solution.",
-			"support_link": "https://preten.do/160-8426"
+			"support_link": "https://preten.do/165-8426"
 		}
 	}
 }

--- a/data/165/9901/en_US.json
+++ b/data/165/9901/en_US.json
@@ -7,7 +7,7 @@
 			"long_description": "Unknown cause.",
 			"short_solution": "Unknown solution.",
 			"long_solution": "Unknown solution.",
-			"support_link": "https://preten.do/160-9901"
+			"support_link": "https://preten.do/165-9901"
 		}
 	}
 }


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves #32 

### Changes:

Corrected the support_url for the error codes, where it was wrong

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

- [X] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [X] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [ ] I have tested all of my changes.