### PR TITLE
chore: 015 error category applies to 3DS family systems, not Wii U

### DIFF
--- a/data/015/2004/en_US.json
+++ b/data/015/2004/en_US.json
@@ -6,7 +6,7 @@
 			"short_description": "Server error.",
 			"long_description": "This error indicates a connection problem with the server.",
 			"short_solution": "Check server status and try again later.",
-			"long_solution": "- **Check our network status information**\n> Check our [Network Status page](https://stats.uptimerobot.com/R7E4wiGjJq) and ensure that there are no ongoing service outages.\n\n- **Ensure your Wii U can connect to the internet and try again**\n> Try performing a connection test in system settings. If the connection test fails, there is likely another issues on your network.",
+			"long_solution": "- **Check our network status information**\n> Check our [Network Status page](https://stats.uptimerobot.com/R7E4wiGjJq) and ensure that there are no ongoing service outages.\n\n- **Ensure your console can connect to the internet and try again**\n> Try performing a connection test in System Settings. If the connection test fails, there is likely another issue on your network.",
 			"support_link": "https://preten.do/015-2004"
 		}
 	}

--- a/data/015/en_US.json
+++ b/data/015/en_US.json
@@ -2,6 +2,6 @@
 	"015": {
 		"name": "olv",
 		"description": "Miiverse",
-		"system": "Wii U"
+		"system": "3DS Family"
 	}
 }

--- a/data/115/2004/en_US.json
+++ b/data/115/2004/en_US.json
@@ -6,7 +6,7 @@
 			"short_description": "Server error.",
 			"long_description": "This error indicates a connection problem with the server.",
 			"short_solution": "Check server status and try again later.",
-			"long_solution": "- **Check our network status information**\n> Check our [Network Status page](https://stats.uptimerobot.com/R7E4wiGjJq) and ensure that there are no ongoing service outages.\n\n- **Ensure your Wii U can connect to the internet and try again**\n> Try performing a connection test in system settings. If the connection test fails, there is likely another issues on your network.",
+			"long_solution": "- **Check our network status information**\n> Check our [Network Status page](https://stats.uptimerobot.com/R7E4wiGjJq) and ensure that there are no ongoing service outages.\n\n- **Ensure your Wii U can connect to the internet and try again**\n> Try performing a connection test in System Settings. If the connection test fails, there is likely another issue on your network.",
 			"support_link": "https://preten.do/115-2004"
 		}
 	}


### PR DESCRIPTION
Resolves #XXX

### Changes:

* The 015 (Miiverse) error category now indicates 3DS Family instead of Wii U.
* Minor typographic fixes.

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [ ] I have tested all of my changes.